### PR TITLE
Update: Support staticcheck deprecation detection in golangci-lint

### DIFF
--- a/client/manager.go
+++ b/client/manager.go
@@ -30,6 +30,8 @@ type TokenManager struct {
 }
 
 // NewMidgardTokenManager returns a new TokenManager backed by midgard.
+//
+// Deprecated: NewMidgardTokenManager() is deprecated in favor or go.aporeto.io/midgardlib/tokenmanager.NewX509TokenManager().
 func NewMidgardTokenManager(url string, validity time.Duration, tlsConfig *tls.Config) *TokenManager {
 
 	fmt.Fprintln(os.Stderr, "DEPRECATED: NewMidgardTokenManager() is deprecated in favor or go.aporeto.io/midgardlib/tokenmanager.NewX509TokenManager()")

--- a/client/options.go
+++ b/client/options.go
@@ -47,7 +47,8 @@ func OptOpaque(opaque map[string]string) Option {
 }
 
 // OptAudience passes the requested audience for the token.
-// Using audience is deprecated. Switch to OptLimitAuthz.
+//
+// Deprecated: Using OptAudience is deprecated. Switch to OptLimitAuthz.
 func OptAudience(audience string) Option {
 
 	return func(opts *issueOpts) {

--- a/client/utils.go
+++ b/client/utils.go
@@ -109,6 +109,7 @@ func ExtractJWTFromHeader(header http.Header) (string, error) {
 }
 
 // VerifyTokenSignature verifies the jwt locally using the given certificate.
+//
 // Deprecated: VerifyTokenSignature is deprecated in favor of VerifyToken()
 func VerifyTokenSignature(tokenString string, cert *x509.Certificate) ([]string, error) {
 


### PR DESCRIPTION
#### Description
We can leverage golangci-lint's `staticcheck` to help detect and force migration from deprecated functions. To do this, we need to slightly modify how we declare this by having a commented out space between where we call deprecation and the function description.