### PR TITLE
Update: Revert enforcing OptAudience deprecation

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -47,8 +47,7 @@ func OptOpaque(opaque map[string]string) Option {
 }
 
 // OptAudience passes the requested audience for the token.
-//
-// Deprecated: Using OptAudience is deprecated. Switch to OptLimitAuthz.
+// Using OptAudience is deprecated. Switch to OptLimitAuthz. (TODO: Find real mapping as OptLimitAuthz does not exist)
 func OptAudience(audience string) Option {
 
 	return func(opts *issueOpts) {


### PR DESCRIPTION
#### Description
There is no `OptLimitAuthz` function and apoctl leverages this field, so we need to remove enforcement until someone with the know-how can clean this deprecation up.