### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -22,9 +22,9 @@ jobs:
           - "1.20"
           - "1.21"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
         with:
           go-version: ${{ matrix.go }}
           cache: true
@@ -37,7 +37,7 @@ jobs:
         run: |
           make
 
-      - uses: PaloAltoNetworks/cov@3.0.0
+      - uses: PaloAltoNetworks/cov@3c863a1458c9ae685c4332af25700920818aa0d2 # 3.0.0
         with:
           main_branch: master
           cov_file: unit_coverage.out

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           make
 
-      - uses: PaloAltoNetworks/cov@3c863a1458c9ae685c4332af25700920818aa0d2 # 3.0.0
+      - uses: PaloAltoNetworks/cov@d48812e1c0a3f4f056c104411b410b2957c51f91 # 3.2.1
         with:
           main_branch: master
           cov_file: unit_coverage.out

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -38,8 +38,8 @@ jobs:
           make
 
       - uses: PaloAltoNetworks/cov@d48812e1c0a3f4f056c104411b410b2957c51f91 # 3.2.1
+        if: matrix.go == '1.21'
         with:
-          if: matrix.go == '1.21'
           main_branch: master
           cov_file: unit_coverage.out
           cov_threshold: "85"

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: setup
         run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
 
       - name: build
         run: |
@@ -39,6 +39,7 @@ jobs:
 
       - uses: PaloAltoNetworks/cov@d48812e1c0a3f4f056c104411b410b2957c51f91 # 3.2.1
         with:
+          if: go.mtrix == '1.21'
           main_branch: master
           cov_file: unit_coverage.out
           cov_threshold: "85"

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: PaloAltoNetworks/cov@d48812e1c0a3f4f056c104411b410b2957c51f91 # 3.2.1
         with:
-          if: go.mtrix == '1.21'
+          if: matrix.go == '1.21'
           main_branch: master
           cov_file: unit_coverage.out
           cov_threshold: "85"

--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -10,7 +10,7 @@ jobs:
   cov:
     runs-on: ubuntu-latest
     steps:
-      - uses: PaloAltoNetworks/cov@3.0.0
+      - uses: PaloAltoNetworks/cov@3c863a1458c9ae685c4332af25700920818aa0d2 # 3.0.0
         with:
           cov_mode: send-status
           workflow_run_id: ${{github.event.workflow_run.id}}

--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -10,7 +10,7 @@ jobs:
   cov:
     runs-on: ubuntu-latest
     steps:
-      - uses: PaloAltoNetworks/cov@3c863a1458c9ae685c4332af25700920818aa0d2 # 3.0.0
+      - uses: PaloAltoNetworks/cov@d48812e1c0a3f4f056c104411b410b2957c51f91 # 3.2.1
         with:
           cov_mode: send-status
           workflow_run_id: ${{github.event.workflow_run.id}}


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Note:
- Includes updates to update PaloAltoNetworks/cov 3.0.0 -> 3.2.1 to resolve an issue with a referenced action being deprecated - https://github.com/PaloAltoNetworks/cov/commit/d48812e1c0a3f4f056c104411b410b2957c51f91
- Pin go mod to older version so it builds now
- Only run coverage once (bug)